### PR TITLE
password validator

### DIFF
--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -66,4 +66,14 @@ describe(validatePassword.name, () => {
     expect(response.errors).toContain("InvalidLength");
     expect(response.errors).toContain("MissingUppercase");
   });
+
+  it("returns errors for long password without a digit or an upper case letter", () => {
+    const response = validatePassword("suchlengthsuchwow");
+
+    expect(response.result).toEqual(false);
+    expect(response.errors.length).toEqual(3);
+    expect(response.errors).toContain("InvalidLength");
+    expect(response.errors).toContain("MissingUppercase");
+    expect(response.errors).toContain("MissingDigit");
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -1,34 +1,42 @@
 import { validatePassword } from "./";
 
 describe(validatePassword.name, () => {
-  it("returns true for password between 5 and 15 characters and containing a digit", () => {
-    const response = validatePassword("agoodpassw0rd");
+  it("returns true for password between 5 and 15 characters, containing a digit and an upper case letter", () => {
+    const response = validatePassword("agoodPassw0rd");
 
     expect(response.result).toEqual(true);
     expect(response.errors.length).toEqual(0);
   });
 
-  it("returns error for short password containing a digit", () => {
-    const response = validatePassword("t1ny");
+  it("returns error for short password containing a digit and an upper case letter", () => {
+    const response = validatePassword("t1Ny");
 
     expect(response.result).toEqual(false);
     expect(response.errors.length).toEqual(1);
     expect(response.errors[0]).toEqual("InvalidLength");
   });
 
-  it("returns error for long password containing a digit", () => {
-    const response = validatePassword("suchl3ngthsuchwow");
+  it("returns error for long password containing a digit and an upper case letter", () => {
+    const response = validatePassword("suchl3ngthsuchwoW");
 
     expect(response.result).toEqual(false);
     expect(response.errors.length).toEqual(1);
     expect(response.errors[0]).toEqual("InvalidLength");
   });
 
-  it("returns error for password between 5 and 15 characters without a digit", () => {
-    const response = validatePassword("apassnodigit");
+  it("returns error for password between 5 and 15 characters with an upper case letter without a digit", () => {
+    const response = validatePassword("apassNodigit");
 
     expect(response.result).toEqual(false);
     expect(response.errors.length).toEqual(1);
     expect(response.errors[0]).toEqual("MissingDigit");
+  });
+
+  it("returns error for password between 5 and 15 characters with a digit without an upper case letter", () => {
+    const response = validatePassword("apassn0upper");
+
+    expect(response.result).toEqual(false);
+    expect(response.errors.length).toEqual(1);
+    expect(response.errors[0]).toEqual("MissingUppercase");
   });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -1,8 +1,8 @@
 import { validatePassword } from "./";
 
 describe(validatePassword.name, () => {
-  it("returns true for password between 5 and 15 characters, containing a digit and an upper case letter", () => {
-    const response = validatePassword("agoodPassw0rd");
+  it.each(["agoodPassw0rd"])("returns true for %s", (password) => {
+    const response = validatePassword(password);
 
     expect(response.result).toEqual(true);
     expect(response.errors.length).toEqual(0);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -1,12 +1,15 @@
 import { validatePassword } from "./";
 
 describe(validatePassword.name, () => {
-  it.each(["agoodPassw0rd"])("returns true for %s", (password) => {
-    const response = validatePassword(password);
+  it.each(["agoodPassw0rd", "aPasswiThD1g1t", "secR3t"])(
+    "validates '%s' is a valid password",
+    (password) => {
+      const response = validatePassword(password);
 
-    expect(response.result).toEqual(true);
-    expect(response.errors.length).toEqual(0);
-  });
+      expect(response.result).toEqual(true);
+      expect(response.errors.length).toEqual(0);
+    }
+  );
 
   it("returns error for short password containing a digit and an upper case letter", () => {
     const response = validatePassword("t1Ny");

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -8,4 +8,12 @@ describe(validatePassword.name, () => {
     expect(response.errors.length).toEqual(1);
     expect(response.errors[0]).toEqual("InvalidLength");
   });
+
+  it("returns error for long password", () => {
+    const response = validatePassword("suchlengthsuchwow");
+
+    expect(response.result).toEqual(false);
+    expect(response.errors.length).toEqual(1);
+    expect(response.errors[0]).toEqual("InvalidLength");
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -67,6 +67,15 @@ describe(validatePassword.name, () => {
     expect(response.errors).toContain("MissingUppercase");
   });
 
+  it("returns errors for long password with an upper case letter without a digit", () => {
+    const response = validatePassword("suchlEngthsuchwow");
+
+    expect(response.result).toEqual(false);
+    expect(response.errors.length).toEqual(2);
+    expect(response.errors).toContain("InvalidLength");
+    expect(response.errors).toContain("MissingDigit");
+  });
+
   it("returns errors for long password without a digit or an upper case letter", () => {
     const response = validatePassword("suchlengthsuchwow");
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -1,6 +1,13 @@
 import { validatePassword } from "./";
 
 describe(validatePassword.name, () => {
+  it("returns true for password between 5 and 15 characters", () => {
+    const response = validatePassword("agoodpassword");
+
+    expect(response.result).toEqual(true);
+    expect(response.errors.length).toEqual(0);
+  });
+
   it("returns error for short password", () => {
     const response = validatePassword("tiny");
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -39,4 +39,13 @@ describe(validatePassword.name, () => {
     expect(response.errors.length).toEqual(1);
     expect(response.errors[0]).toEqual("MissingUppercase");
   });
+
+  it("returns errors for password between 5 and 15 characters without a digit or an upper case letter", () => {
+    const response = validatePassword("apass");
+
+    expect(response.result).toEqual(false);
+    expect(response.errors.length).toEqual(2);
+    expect(response.errors).toContain("MissingDigit");
+    expect(response.errors).toContain("MissingUppercase");
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -24,6 +24,9 @@ describe(validatePassword.name, () => {
       "suchlengthsuchwow",
       ["InvalidLength", "MissingUppercase", "MissingDigit"],
     ],
+    ["maxwell1_c", ["MissingUppercase"]],
+    ["maxwellTheBe", ["MissingDigit"]],
+    ["thePhysical1234567", ["InvalidLength"]],
   ])("returns error for '%s'", (password, errors) => {
     const response = validatePassword(password);
     expect(response.result).toEqual(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -2,14 +2,14 @@ import { validatePassword } from "./";
 
 describe(validatePassword.name, () => {
   it("returns true for password between 5 and 15 characters", () => {
-    const response = validatePassword("agoodpassword");
+    const response = validatePassword("agoodpassw0rd");
 
     expect(response.result).toEqual(true);
     expect(response.errors.length).toEqual(0);
   });
 
   it("returns error for short password", () => {
-    const response = validatePassword("tiny");
+    const response = validatePassword("t1ny");
 
     expect(response.result).toEqual(false);
     expect(response.errors.length).toEqual(1);
@@ -17,10 +17,18 @@ describe(validatePassword.name, () => {
   });
 
   it("returns error for long password", () => {
-    const response = validatePassword("suchlengthsuchwow");
+    const response = validatePassword("suchl3ngthsuchwow");
 
     expect(response.result).toEqual(false);
     expect(response.errors.length).toEqual(1);
     expect(response.errors[0]).toEqual("InvalidLength");
+  });
+
+  it("returns error for password without a digit", () => {
+    const response = validatePassword("apassnodigit");
+
+    expect(response.result).toEqual(false);
+    expect(response.errors.length).toEqual(1);
+    expect(response.errors[0]).toEqual("MissingDigit");
   });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -57,4 +57,13 @@ describe(validatePassword.name, () => {
     expect(response.errors).toContain("InvalidLength");
     expect(response.errors).toContain("MissingUppercase");
   });
+
+  it("returns errors for long password with a digit without an upper case letter", () => {
+    const response = validatePassword("suchl3ngthsuchwow");
+
+    expect(response.result).toEqual(false);
+    expect(response.errors.length).toEqual(2);
+    expect(response.errors).toContain("InvalidLength");
+    expect(response.errors).toContain("MissingUppercase");
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -5,87 +5,31 @@ describe(validatePassword.name, () => {
     "validates '%s' is a valid password",
     (password) => {
       const response = validatePassword(password);
-
       expect(response.result).toEqual(true);
       expect(response.errors.length).toEqual(0);
     }
   );
 
-  it("returns error for short password containing a digit and an upper case letter", () => {
-    const response = validatePassword("t1Ny");
-
+  it.each([
+    ["t1Ny", ["InvalidLength"]],
+    ["suchl3ngthsuchwoW", ["InvalidLength"]],
+    ["apassNodigit", ["MissingDigit"]],
+    ["apassn0upper", ["MissingUppercase"]],
+    ["apass", ["MissingDigit", "MissingUppercase"]],
+    ["t1ny", ["InvalidLength", "MissingUppercase"]],
+    ["t1ny", ["InvalidLength", "MissingUppercase"]],
+    ["suchl3ngthsuchwow", ["InvalidLength", "MissingUppercase"]],
+    ["suchlEngthsuchwow", ["InvalidLength", "MissingDigit"]],
+    [
+      "suchlengthsuchwow",
+      ["InvalidLength", "MissingUppercase", "MissingDigit"],
+    ],
+  ])("returns error for '%s'", (password, errors) => {
+    const response = validatePassword(password);
     expect(response.result).toEqual(false);
-    expect(response.errors.length).toEqual(1);
-    expect(response.errors).toContain("InvalidLength");
-  });
-
-  it("returns error for long password containing a digit and an upper case letter", () => {
-    const response = validatePassword("suchl3ngthsuchwoW");
-
-    expect(response.result).toEqual(false);
-    expect(response.errors.length).toEqual(1);
-    expect(response.errors).toContain("InvalidLength");
-  });
-
-  it("returns error for password between 5 and 15 characters with an upper case letter without a digit", () => {
-    const response = validatePassword("apassNodigit");
-
-    expect(response.result).toEqual(false);
-    expect(response.errors.length).toEqual(1);
-    expect(response.errors).toContain("MissingDigit");
-  });
-
-  it("returns error for password between 5 and 15 characters with a digit without an upper case letter", () => {
-    const response = validatePassword("apassn0upper");
-
-    expect(response.result).toEqual(false);
-    expect(response.errors.length).toEqual(1);
-    expect(response.errors).toContain("MissingUppercase");
-  });
-
-  it("returns errors for password between 5 and 15 characters without a digit or an upper case letter", () => {
-    const response = validatePassword("apass");
-
-    expect(response.result).toEqual(false);
-    expect(response.errors.length).toEqual(2);
-    expect(response.errors).toContain("MissingDigit");
-    expect(response.errors).toContain("MissingUppercase");
-  });
-
-  it("returns errors for short password with a digit without an upper case letter", () => {
-    const response = validatePassword("t1ny");
-
-    expect(response.result).toEqual(false);
-    expect(response.errors.length).toEqual(2);
-    expect(response.errors).toContain("InvalidLength");
-    expect(response.errors).toContain("MissingUppercase");
-  });
-
-  it("returns errors for long password with a digit without an upper case letter", () => {
-    const response = validatePassword("suchl3ngthsuchwow");
-
-    expect(response.result).toEqual(false);
-    expect(response.errors.length).toEqual(2);
-    expect(response.errors).toContain("InvalidLength");
-    expect(response.errors).toContain("MissingUppercase");
-  });
-
-  it("returns errors for long password with an upper case letter without a digit", () => {
-    const response = validatePassword("suchlEngthsuchwow");
-
-    expect(response.result).toEqual(false);
-    expect(response.errors.length).toEqual(2);
-    expect(response.errors).toContain("InvalidLength");
-    expect(response.errors).toContain("MissingDigit");
-  });
-
-  it("returns errors for long password without a digit or an upper case letter", () => {
-    const response = validatePassword("suchlengthsuchwow");
-
-    expect(response.result).toEqual(false);
-    expect(response.errors.length).toEqual(3);
-    expect(response.errors).toContain("InvalidLength");
-    expect(response.errors).toContain("MissingUppercase");
-    expect(response.errors).toContain("MissingDigit");
+    expect(response.errors.length).toEqual(errors.length);
+    for (const error of errors) {
+      expect(response.errors).toContain(error);
+    }
   });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -13,7 +13,7 @@ describe(validatePassword.name, () => {
 
     expect(response.result).toEqual(false);
     expect(response.errors.length).toEqual(1);
-    expect(response.errors[0]).toEqual("InvalidLength");
+    expect(response.errors).toContain("InvalidLength");
   });
 
   it("returns error for long password containing a digit and an upper case letter", () => {
@@ -21,7 +21,7 @@ describe(validatePassword.name, () => {
 
     expect(response.result).toEqual(false);
     expect(response.errors.length).toEqual(1);
-    expect(response.errors[0]).toEqual("InvalidLength");
+    expect(response.errors).toContain("InvalidLength");
   });
 
   it("returns error for password between 5 and 15 characters with an upper case letter without a digit", () => {
@@ -29,7 +29,7 @@ describe(validatePassword.name, () => {
 
     expect(response.result).toEqual(false);
     expect(response.errors.length).toEqual(1);
-    expect(response.errors[0]).toEqual("MissingDigit");
+    expect(response.errors).toContain("MissingDigit");
   });
 
   it("returns error for password between 5 and 15 characters with a digit without an upper case letter", () => {
@@ -37,7 +37,7 @@ describe(validatePassword.name, () => {
 
     expect(response.result).toEqual(false);
     expect(response.errors.length).toEqual(1);
-    expect(response.errors[0]).toEqual("MissingUppercase");
+    expect(response.errors).toContain("MissingUppercase");
   });
 
   it("returns errors for password between 5 and 15 characters without a digit or an upper case letter", () => {

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -1,5 +1,11 @@
+import { validatePassword } from "./";
 
-describe('password validator', () => {
+describe(validatePassword.name, () => {
+  it("returns error for short password", () => {
+    const response = validatePassword("tiny");
 
-})
-
+    expect(response.result).toEqual(false);
+    expect(response.errors.length).toEqual(1);
+    expect(response.errors[0]).toEqual("InvalidLength");
+  });
+});

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -48,4 +48,13 @@ describe(validatePassword.name, () => {
     expect(response.errors).toContain("MissingDigit");
     expect(response.errors).toContain("MissingUppercase");
   });
+
+  it("returns errors for short password with a digit without an upper case letter", () => {
+    const response = validatePassword("t1ny");
+
+    expect(response.result).toEqual(false);
+    expect(response.errors.length).toEqual(2);
+    expect(response.errors).toContain("InvalidLength");
+    expect(response.errors).toContain("MissingUppercase");
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.spec.ts
@@ -1,14 +1,14 @@
 import { validatePassword } from "./";
 
 describe(validatePassword.name, () => {
-  it("returns true for password between 5 and 15 characters", () => {
+  it("returns true for password between 5 and 15 characters and containing a digit", () => {
     const response = validatePassword("agoodpassw0rd");
 
     expect(response.result).toEqual(true);
     expect(response.errors.length).toEqual(0);
   });
 
-  it("returns error for short password", () => {
+  it("returns error for short password containing a digit", () => {
     const response = validatePassword("t1ny");
 
     expect(response.result).toEqual(false);
@@ -16,7 +16,7 @@ describe(validatePassword.name, () => {
     expect(response.errors[0]).toEqual("InvalidLength");
   });
 
-  it("returns error for long password", () => {
+  it("returns error for long password containing a digit", () => {
     const response = validatePassword("suchl3ngthsuchwow");
 
     expect(response.result).toEqual(false);
@@ -24,7 +24,7 @@ describe(validatePassword.name, () => {
     expect(response.errors[0]).toEqual("InvalidLength");
   });
 
-  it("returns error for password without a digit", () => {
+  it("returns error for password between 5 and 15 characters without a digit", () => {
     const response = validatePassword("apassnodigit");
 
     expect(response.result).toEqual(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -1,6 +1,13 @@
 export function validatePassword(password: string) {
+  if (password.length < 5 || password.length > 15) {
+    return {
+      result: false,
+      errors: ["InvalidLength"],
+    };
+  }
+
   return {
-    result: false,
-    errors: ["InvalidLength"],
+    result: true,
+    errors: [],
   };
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -1,4 +1,4 @@
-type Errors = "InvalidLength" | "MissingDigit";
+type Errors = "InvalidLength" | "MissingDigit" | "MissingUppercase";
 
 interface ValidatePasswordResponse {
   result: boolean;
@@ -17,6 +17,11 @@ export function validatePassword(password: string): ValidatePasswordResponse {
   if (!/[0-9]/.test(password)) {
     result = false;
     errors.push("MissingDigit");
+  }
+
+  if (!/[A-Z]/.test(password)) {
+    result = false;
+    errors.push("MissingUppercase");
   }
 
   return {

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -1,0 +1,6 @@
+export function validatePassword(password: string) {
+  return {
+    result: false,
+    errors: ["InvalidLength"],
+  };
+}

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -1,13 +1,19 @@
 export function validatePassword(password: string) {
+  let result = true;
+  let errors: string[] = [];
+
   if (password.length < 5 || password.length > 15) {
-    return {
-      result: false,
-      errors: ["InvalidLength"],
-    };
+    result = false;
+    errors.push("InvalidLength");
+  }
+
+  if (!/[0-9]/.test(password)) {
+    result = false;
+    errors.push("MissingDigit");
   }
 
   return {
-    result: true,
-    errors: [],
+    result,
+    errors,
   };
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/2_Arrange_Act_Assert/2_1_Password_Validator/src/index.ts
@@ -1,6 +1,13 @@
-export function validatePassword(password: string) {
+type Errors = "InvalidLength" | "MissingDigit";
+
+interface ValidatePasswordResponse {
+  result: boolean;
+  errors: Errors[];
+}
+
+export function validatePassword(password: string): ValidatePasswordResponse {
   let result = true;
-  let errors: string[] = [];
+  let errors: Errors[] = [];
 
   if (password.length < 5 || password.length > 15) {
     result = false;


### PR DESCRIPTION
- feat(password): return error for short password
- feat(password): return error for long password
- feat(password): return true for password between 5 and 15 chars
- feat(password): return error for password without a digit
- refactor(password): update test names
- refactor(password): add response type
- feat(password): return error for password without an upper case letter
- test(password): add test
- test(password): add test
- test(password): add test
- test(password): add test
- test(password): add test
