### PR TITLE
military time validator

### DIFF
--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/requirements.md
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/requirements.md
@@ -1,0 +1,7 @@
+Write a function (or a stateless class) capable of validating whether a string time range is a valid military time range or not.
+
+Examples:
+
+"01:12 - 14:32" (yes)
+"25:00 - 12:23" (no)
+"22:00 - 23:12" (yes)

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -7,7 +7,7 @@ describe("military time validator", () => {
     expect(res).toBe(true);
   });
 
-  it.each(["", "12:34", "12:34 - "])(
+  it.each(["", "12:34", "12:34 - ", " - 01:23"])(
     'knows that "%s" is not a valid range',
     (range) => {
       const res = MilitaryTimeValidator.validateRange(range);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -20,6 +20,7 @@ describe("military time validator", () => {
     " - 01:23",
     "12:34 - 1345",
     "1234 - 13:45",
+    "13:34 - 08:45",
   ])('knows that "%s" is not a valid range', (range) => {
     const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -21,6 +21,7 @@ describe("military time validator", () => {
     "12:34 - 1345",
     "1234 - 13:45",
     "13:34 - 08:45",
+    "08:45 - 08:34",
   ])('knows that "%s" is not a valid range', (range) => {
     const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -13,6 +13,12 @@ describe("military time validator", () => {
     expect(res).toBe(true);
   });
 
+  it('knows that "22:00 - 23:12" is a valid range', () => {
+    const range = "22:00 - 23:12";
+    const res = MilitaryTimeValidator.validateRange(range);
+    expect(res).toBe(true);
+  });
+
   it.each([
     "",
     "12:34",

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -9,4 +9,13 @@ describe("military time validator", () => {
 
     expect(res).toBe(true);
   });
+
+  it("knows that an empty string is not a valid range", () => {
+    const range = "";
+    const militaryTimeValidator = new MilitaryTimeValidator();
+
+    const res = militaryTimeValidator.validateRange(range);
+
+    expect(res).toBe(false);
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -30,6 +30,7 @@ describe("military time validator", () => {
     "12:-34 - 13:23",
     "12:34 - 13:-23",
     "12:34 to 13:23",
+    "12:34 - 13:23 - 17:51",
   ])('knows that "%s" is not a valid range', (range) => {
     expect(MilitaryTimeValidator.validateRange(range)).toBe(false);
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -21,6 +21,7 @@ describe("military time validator", () => {
     "25:00 - 12:23",
     "12:23 - 25:00",
     "12:23 - 24:01",
+    "00:00 - 24:00",
   ])('knows that "%s" is not a valid range', (range) => {
     const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -29,6 +29,7 @@ describe("military time validator", () => {
     "12:34 - -13:23",
     "12:-34 - 13:23",
     "12:34 - 13:-23",
+    "12:34 to 13:23",
   ])('knows that "%s" is not a valid range', (range) => {
     expect(MilitaryTimeValidator.validateRange(range)).toBe(false);
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -25,6 +25,7 @@ describe("military time validator", () => {
     "12:23 - 24:01",
     "00:00 - 24:00",
     "12:34 - 13:60",
+    "12:61 - 13:23",
   ])('knows that "%s" is not a valid range', (range) => {
     const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -26,6 +26,7 @@ describe("military time validator", () => {
     "12:34 - 13:60",
     "12:61 - 13:23",
     "-12:34 - 13:23",
+    "12:34 - -13:23",
   ])('knows that "%s" is not a valid range', (range) => {
     expect(MilitaryTimeValidator.validateRange(range)).toBe(false);
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -7,21 +7,11 @@ describe("military time validator", () => {
     expect(res).toBe(true);
   });
 
-  it("knows that an empty string is not a valid range", () => {
-    const range = "";
-    const res = MilitaryTimeValidator.validateRange(range);
-    expect(res).toBe(false);
-  });
-
-  it('knows that "12:34" is not a valid range', () => {
-    const range = "12:34";
-    const res = MilitaryTimeValidator.validateRange(range);
-    expect(res).toBe(false);
-  });
-
-  it('knows that "12:34 - " is not a valid range', () => {
-    const range = "12:34 - ";
-    const res = MilitaryTimeValidator.validateRange(range);
-    expect(res).toBe(false);
-  });
+  it.each(["", "12:34", "12:34 - "])(
+    'knows that "%s" is not a valid range',
+    (range) => {
+      const res = MilitaryTimeValidator.validateRange(range);
+      expect(res).toBe(false);
+    }
+  );
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -1,5 +1,12 @@
+import { MilitaryTimeValidator } from "./";
 
-describe('military time validator', () => {
+describe("military time validator", () => {
+  it('knows that "01:12 - 14:32" is a valid range', () => {
+    const range = "01:12 - 14:32";
+    const militaryTimeValidator = new MilitaryTimeValidator();
 
+    const res = militaryTimeValidator.validateRange(range);
 
-})
+    expect(res).toBe(true);
+  });
+});

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -3,28 +3,19 @@ import { MilitaryTimeValidator } from "./";
 describe("military time validator", () => {
   it('knows that "01:12 - 14:32" is a valid range', () => {
     const range = "01:12 - 14:32";
-    const militaryTimeValidator = new MilitaryTimeValidator();
-
-    const res = militaryTimeValidator.validateRange(range);
-
+    const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(true);
   });
 
   it("knows that an empty string is not a valid range", () => {
     const range = "";
-    const militaryTimeValidator = new MilitaryTimeValidator();
-
-    const res = militaryTimeValidator.validateRange(range);
-
+    const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);
   });
 
   it('knows that "12:34" is not a valid range', () => {
     const range = "12:34";
-    const militaryTimeValidator = new MilitaryTimeValidator();
-
-    const res = militaryTimeValidator.validateRange(range);
-
+    const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);
   });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -1,13 +1,17 @@
 import { MilitaryTimeValidator } from "./";
 
 describe("military time validator", () => {
-  it.each(["01:12 - 14:32", "12:34 - 13:45", "22:00 - 23:12", "00:00 - 23:59"])(
-    'knows that "%s" is a valid range',
-    (range) => {
-      const res = MilitaryTimeValidator.validateRange(range);
-      expect(res).toBe(true);
-    }
-  );
+  it.each([
+    "01:12 - 14:32",
+    "12:34 - 13:45",
+    "22:00 - 23:12",
+    "00:00 - 23:59",
+    "13:34 - 08:45",
+    "08:45 - 08:34",
+  ])('knows that "%s" is a valid range', (range) => {
+    const res = MilitaryTimeValidator.validateRange(range);
+    expect(res).toBe(true);
+  });
 
   it.each([
     "",
@@ -16,8 +20,6 @@ describe("military time validator", () => {
     " - 01:23",
     "12:34 - 1345",
     "1234 - 13:45",
-    "13:34 - 08:45",
-    "08:45 - 08:34",
     "25:00 - 12:23",
     "12:23 - 25:00",
     "12:23 - 24:01",

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -7,11 +7,15 @@ describe("military time validator", () => {
     expect(res).toBe(true);
   });
 
-  it.each(["", "12:34", "12:34 - ", " - 01:23", "12:34 - 1345"])(
-    'knows that "%s" is not a valid range',
-    (range) => {
-      const res = MilitaryTimeValidator.validateRange(range);
-      expect(res).toBe(false);
-    }
-  );
+  it.each([
+    "",
+    "12:34",
+    "12:34 - ",
+    " - 01:23",
+    "12:34 - 1345",
+    "1234 - 13:45",
+  ])('knows that "%s" is not a valid range', (range) => {
+    const res = MilitaryTimeValidator.validateRange(range);
+    expect(res).toBe(false);
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -7,6 +7,12 @@ describe("military time validator", () => {
     expect(res).toBe(true);
   });
 
+  it('knows that "12:34 - 13:45" is a valid range', () => {
+    const range = "12:34 - 13:45";
+    const res = MilitaryTimeValidator.validateRange(range);
+    expect(res).toBe(true);
+  });
+
   it.each([
     "",
     "12:34",

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -19,6 +19,7 @@ describe("military time validator", () => {
     "13:34 - 08:45",
     "08:45 - 08:34",
     "25:00 - 12:23",
+    "12:23 - 25:00",
   ])('knows that "%s" is not a valid range', (range) => {
     const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -24,6 +24,7 @@ describe("military time validator", () => {
     "12:23 - 25:00",
     "12:23 - 24:01",
     "00:00 - 24:00",
+    "12:34 - 13:60",
   ])('knows that "%s" is not a valid range', (range) => {
     const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -1,23 +1,13 @@
 import { MilitaryTimeValidator } from "./";
 
 describe("military time validator", () => {
-  it('knows that "01:12 - 14:32" is a valid range', () => {
-    const range = "01:12 - 14:32";
-    const res = MilitaryTimeValidator.validateRange(range);
-    expect(res).toBe(true);
-  });
-
-  it('knows that "12:34 - 13:45" is a valid range', () => {
-    const range = "12:34 - 13:45";
-    const res = MilitaryTimeValidator.validateRange(range);
-    expect(res).toBe(true);
-  });
-
-  it('knows that "22:00 - 23:12" is a valid range', () => {
-    const range = "22:00 - 23:12";
-    const res = MilitaryTimeValidator.validateRange(range);
-    expect(res).toBe(true);
-  });
+  it.each(["01:12 - 14:32", "12:34 - 13:45", "22:00 - 23:12"])(
+    'knows that "%s" is a valid range',
+    (range) => {
+      const res = MilitaryTimeValidator.validateRange(range);
+      expect(res).toBe(true);
+    }
+  );
 
   it.each([
     "",

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -18,4 +18,10 @@ describe("military time validator", () => {
     const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);
   });
+
+  it('knows that "12:34 - " is not a valid range', () => {
+    const range = "12:34 - ";
+    const res = MilitaryTimeValidator.validateRange(range);
+    expect(res).toBe(false);
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -27,6 +27,7 @@ describe("military time validator", () => {
     "12:61 - 13:23",
     "-12:34 - 13:23",
     "12:34 - -13:23",
+    "12:-34 - 13:23",
   ])('knows that "%s" is not a valid range', (range) => {
     expect(MilitaryTimeValidator.validateRange(range)).toBe(false);
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -9,8 +9,7 @@ describe("military time validator", () => {
     "13:34 - 08:45",
     "08:45 - 08:34",
   ])('knows that "%s" is a valid range', (range) => {
-    const res = MilitaryTimeValidator.validateRange(range);
-    expect(res).toBe(true);
+    expect(MilitaryTimeValidator.validateRange(range)).toBe(true);
   });
 
   it.each([
@@ -27,7 +26,6 @@ describe("military time validator", () => {
     "12:34 - 13:60",
     "12:61 - 13:23",
   ])('knows that "%s" is not a valid range', (range) => {
-    const res = MilitaryTimeValidator.validateRange(range);
-    expect(res).toBe(false);
+    expect(MilitaryTimeValidator.validateRange(range)).toBe(false);
   });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -20,6 +20,7 @@ describe("military time validator", () => {
     "08:45 - 08:34",
     "25:00 - 12:23",
     "12:23 - 25:00",
+    "12:23 - 24:01",
   ])('knows that "%s" is not a valid range', (range) => {
     const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -18,4 +18,13 @@ describe("military time validator", () => {
 
     expect(res).toBe(false);
   });
+
+  it('knows that "12:34" is not a valid range', () => {
+    const range = "12:34";
+    const militaryTimeValidator = new MilitaryTimeValidator();
+
+    const res = militaryTimeValidator.validateRange(range);
+
+    expect(res).toBe(false);
+  });
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -25,6 +25,7 @@ describe("military time validator", () => {
     "00:00 - 24:00",
     "12:34 - 13:60",
     "12:61 - 13:23",
+    "-12:34 - 13:23",
   ])('knows that "%s" is not a valid range', (range) => {
     expect(MilitaryTimeValidator.validateRange(range)).toBe(false);
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -7,7 +7,7 @@ describe("military time validator", () => {
     expect(res).toBe(true);
   });
 
-  it.each(["", "12:34", "12:34 - ", " - 01:23"])(
+  it.each(["", "12:34", "12:34 - ", " - 01:23", "12:34 - 1345"])(
     'knows that "%s" is not a valid range',
     (range) => {
       const res = MilitaryTimeValidator.validateRange(range);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -28,6 +28,7 @@ describe("military time validator", () => {
     "-12:34 - 13:23",
     "12:34 - -13:23",
     "12:-34 - 13:23",
+    "12:34 - 13:-23",
   ])('knows that "%s" is not a valid range', (range) => {
     expect(MilitaryTimeValidator.validateRange(range)).toBe(false);
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -22,6 +22,7 @@ describe("military time validator", () => {
     "1234 - 13:45",
     "13:34 - 08:45",
     "08:45 - 08:34",
+    "25:00 - 12:23",
   ])('knows that "%s" is not a valid range', (range) => {
     const res = MilitaryTimeValidator.validateRange(range);
     expect(res).toBe(false);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -1,7 +1,7 @@
 import { MilitaryTimeValidator } from "./";
 
 describe("military time validator", () => {
-  it.each(["01:12 - 14:32", "12:34 - 13:45", "22:00 - 23:12"])(
+  it.each(["01:12 - 14:32", "12:34 - 13:45", "22:00 - 23:12", "00:00 - 23:59"])(
     'knows that "%s" is a valid range',
     (range) => {
       const res = MilitaryTimeValidator.validateRange(range);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -10,7 +10,7 @@ export class MilitaryTimeValidator {
     const [startHour, startMinute] = start.split(":");
     const [endHour, endMinute] = end.split(":");
     if (parseInt(startHour) >= 24 || parseInt(startHour) < 0) return false;
-    if (parseInt(endHour) >= 24) return false;
+    if (parseInt(endHour) >= 24 || parseInt(endHour) < 0) return false;
     if (parseInt(startMinute) >= 60) return false;
     if (parseInt(endMinute) >= 60) return false;
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -9,7 +9,7 @@ export class MilitaryTimeValidator {
 
     const [startHour, startMinute] = start.split(":");
     const [endHour, endMinute] = end.split(":");
-    if (parseInt(startHour) >= 24) return false;
+    if (parseInt(startHour) >= 24 || parseInt(startHour) < 0) return false;
     if (parseInt(endHour) >= 24) return false;
     if (parseInt(startMinute) >= 60) return false;
     if (parseInt(endMinute) >= 60) return false;

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -11,7 +11,7 @@ export class MilitaryTimeValidator {
     const [endHour, endMinute] = end.split(":");
     if (parseInt(startHour) >= 24 || parseInt(startHour) < 0) return false;
     if (parseInt(endHour) >= 24 || parseInt(endHour) < 0) return false;
-    if (parseInt(startMinute) >= 60) return false;
+    if (parseInt(startMinute) >= 60 || parseInt(startMinute) < 0) return false;
     if (parseInt(endMinute) >= 60) return false;
 
     return Boolean(range);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,20 +1,44 @@
 export class MilitaryTimeValidator {
   static validateRange(range: string): boolean {
-    if (!range.includes("-")) return false;
+    if (!this.rangeHasSeparator(range)) return false;
+    if (!this.rangeHasCorrectNumberOfParts(range)) return false;
 
-    const [start, end, ...rest] = range.split(" - ");
-    if (!start || !end) return false;
-    if (rest.length) return false;
+    const [start, end] = this.getStartAndEndTimes(range);
+    if (!this.isValidTime(start) || !this.isValidTime(end)) return false;
 
-    if (!start.includes(":") || !end.includes(":")) return false;
+    return true;
+  }
 
-    const [startHour, startMinute] = start.split(":");
-    const [endHour, endMinute] = end.split(":");
-    if (parseInt(startHour) >= 24 || parseInt(startHour) < 0) return false;
-    if (parseInt(endHour) >= 24 || parseInt(endHour) < 0) return false;
-    if (parseInt(startMinute) >= 60 || parseInt(startMinute) < 0) return false;
-    if (parseInt(endMinute) >= 60 || parseInt(endMinute) < 0) return false;
+  private static rangeHasSeparator(range: string): boolean {
+    return range.includes("-");
+  }
 
-    return Boolean(range);
+  private static rangeHasCorrectNumberOfParts(range: string): boolean {
+    const parts = range.split(" - ");
+    return parts.length === 2;
+  }
+
+  private static getStartAndEndTimes(range: string): string[] {
+    const [start, end] = range.split(" - ");
+    return [start, end];
+  }
+
+  private static isValidTime(time: string): boolean {
+    if (!this.timeHasSeparator(time)) return false;
+
+    const [hour, minute] = this.getHourAndMinute(time);
+    if (hour >= 24 || hour < 0) return false;
+    if (minute >= 60 || minute < 0) return false;
+
+    return true;
+  }
+
+  private static timeHasSeparator(time: string): boolean {
+    return time.includes(":");
+  }
+
+  private static getHourAndMinute(time: string): number[] {
+    const [hour, minute] = time.split(":").map((t) => parseInt(t));
+    return [hour, minute];
   }
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -5,6 +5,8 @@ export class MilitaryTimeValidator {
     const [start, end] = range.split(" - ");
     if (!start || !end) return false;
 
+    if (!end.includes(":")) return false;
+
     return Boolean(range);
   }
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -2,8 +2,8 @@ export class MilitaryTimeValidator {
   static validateRange(range: string): boolean {
     if (!range.includes("-")) return false;
 
-    const [, end] = range.split(" - ");
-    if (!end) return false;
+    const [start, end] = range.split(" - ");
+    if (!start || !end) return false;
 
     return Boolean(range);
   }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -11,6 +11,7 @@ export class MilitaryTimeValidator {
     const [endHour, endMinute] = end.split(":");
     if (parseInt(startHour) >= 24) return false;
     if (parseInt(endHour) >= 24) return false;
+    if (parseInt(startMinute) >= 60) return false;
     if (parseInt(endMinute) >= 60) return false;
 
     return Boolean(range);

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -7,13 +7,10 @@ export class MilitaryTimeValidator {
 
     if (!start.includes(":") || !end.includes(":")) return false;
 
-    const [startHour, startMinute] = start.split(":");
-    const [endHour, endMinute] = end.split(":");
-    if (startHour > endHour) return false;
+    const [startHour] = start.split(":");
+    const [endHour] = end.split(":");
+    if (parseInt(startHour) >= 24) return false;
     if (parseInt(endHour) >= 24) return false;
-    if (startHour === endHour) {
-      if (startMinute > endMinute) return false;
-    }
 
     return Boolean(range);
   }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,5 +1,5 @@
 export class MilitaryTimeValidator {
-  validateRange(range: string) {
-    return true;
+  validateRange(range: string): boolean {
+    return Boolean(range);
   }
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -10,7 +10,7 @@ export class MilitaryTimeValidator {
     const [startHour, startMinute] = start.split(":");
     const [endHour, endMinute] = end.split(":");
     if (startHour > endHour) return false;
-    if (parseInt(endHour) > 24) return false;
+    if (parseInt(endHour) >= 24) return false;
     if (startHour === endHour) {
       if (startMinute > endMinute) return false;
     }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,5 +1,5 @@
 export class MilitaryTimeValidator {
-  validateRange(range: string): boolean {
+  static validateRange(range: string): boolean {
     if (!range.includes("-")) return false;
     return Boolean(range);
   }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -7,6 +7,10 @@ export class MilitaryTimeValidator {
 
     if (!start.includes(":") || !end.includes(":")) return false;
 
+    const [startHour] = start.split(":");
+    const [endHour] = end.split(":");
+    if (startHour > endHour) return false;
+
     return Boolean(range);
   }
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -7,10 +7,11 @@ export class MilitaryTimeValidator {
 
     if (!start.includes(":") || !end.includes(":")) return false;
 
-    const [startHour] = start.split(":");
-    const [endHour] = end.split(":");
+    const [startHour, startMinute] = start.split(":");
+    const [endHour, endMinute] = end.split(":");
     if (parseInt(startHour) >= 24) return false;
     if (parseInt(endHour) >= 24) return false;
+    if (parseInt(endMinute) >= 60) return false;
 
     return Boolean(range);
   }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -12,7 +12,7 @@ export class MilitaryTimeValidator {
     if (parseInt(startHour) >= 24 || parseInt(startHour) < 0) return false;
     if (parseInt(endHour) >= 24 || parseInt(endHour) < 0) return false;
     if (parseInt(startMinute) >= 60 || parseInt(startMinute) < 0) return false;
-    if (parseInt(endMinute) >= 60) return false;
+    if (parseInt(endMinute) >= 60 || parseInt(endMinute) < 0) return false;
 
     return Boolean(range);
   }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,0 +1,5 @@
+export class MilitaryTimeValidator {
+  validateRange(range: string) {
+    return true;
+  }
+}

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -2,8 +2,9 @@ export class MilitaryTimeValidator {
   static validateRange(range: string): boolean {
     if (!range.includes("-")) return false;
 
-    const [start, end] = range.split(" - ");
+    const [start, end, ...rest] = range.split(" - ");
     if (!start || !end) return false;
+    if (rest.length) return false;
 
     if (!start.includes(":") || !end.includes(":")) return false;
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -5,7 +5,7 @@ export class MilitaryTimeValidator {
     const [start, end] = range.split(" - ");
     if (!start || !end) return false;
 
-    if (!end.includes(":")) return false;
+    if (!start.includes(":") || !end.includes(":")) return false;
 
     return Boolean(range);
   }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,6 +1,10 @@
 export class MilitaryTimeValidator {
   static validateRange(range: string): boolean {
     if (!range.includes("-")) return false;
+
+    const [, end] = range.split(" - ");
+    if (!end) return false;
+
     return Boolean(range);
   }
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -7,9 +7,12 @@ export class MilitaryTimeValidator {
 
     if (!start.includes(":") || !end.includes(":")) return false;
 
-    const [startHour] = start.split(":");
-    const [endHour] = end.split(":");
+    const [startHour, startMinute] = start.split(":");
+    const [endHour, endMinute] = end.split(":");
     if (startHour > endHour) return false;
+    if (startHour === endHour) {
+      if (startMinute > endMinute) return false;
+    }
 
     return Boolean(range);
   }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,5 +1,6 @@
 export class MilitaryTimeValidator {
   validateRange(range: string): boolean {
+    if (!range.includes("-")) return false;
     return Boolean(range);
   }
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -10,6 +10,7 @@ export class MilitaryTimeValidator {
     const [startHour, startMinute] = start.split(":");
     const [endHour, endMinute] = end.split(":");
     if (startHour > endHour) return false;
+    if (parseInt(endHour) > 24) return false;
     if (startHour === endHour) {
       if (startMinute > endMinute) return false;
     }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,12 +1,15 @@
 export class MilitaryTimeValidator {
   static validateRange(range: string): boolean {
-    if (!this.rangeHasSeparator(range)) return false;
-    if (!this.rangeHasCorrectNumberOfParts(range)) return false;
+    if (
+      !this.rangeHasSeparator(range) ||
+      !this.rangeHasCorrectNumberOfParts(range)
+    ) {
+      return false;
+    }
 
     const [start, end] = this.getStartAndEndTimes(range);
-    if (!this.isValidTime(start) || !this.isValidTime(end)) return false;
 
-    return true;
+    return this.isValidTime(start) && this.isValidTime(end);
   }
 
   private static rangeHasSeparator(range: string): boolean {
@@ -14,8 +17,7 @@ export class MilitaryTimeValidator {
   }
 
   private static rangeHasCorrectNumberOfParts(range: string): boolean {
-    const parts = range.split(" - ");
-    return parts.length === 2;
+    return range.split(" - ").length === 2;
   }
 
   private static getStartAndEndTimes(range: string): string[] {
@@ -27,10 +29,8 @@ export class MilitaryTimeValidator {
     if (!this.timeHasSeparator(time)) return false;
 
     const [hour, minute] = this.getHourAndMinute(time);
-    if (hour >= 24 || hour < 0) return false;
-    if (minute >= 60 || minute < 0) return false;
 
-    return true;
+    return this.isValidHour(hour) && this.isValidMinute(minute);
   }
 
   private static timeHasSeparator(time: string): boolean {
@@ -40,5 +40,13 @@ export class MilitaryTimeValidator {
   private static getHourAndMinute(time: string): number[] {
     const [hour, minute] = time.split(":").map((t) => parseInt(t));
     return [hour, minute];
+  }
+
+  private static isValidHour(hour: number): boolean {
+    return hour < 24 && hour >= 0;
+  }
+
+  private static isValidMinute(minute: number): boolean {
+    return minute < 60 && minute >= 0;
   }
 }


### PR DESCRIPTION
- docs(military): add requirements
- feat(military): fake it true
- feat(military): handle empty string
- feat(military): includes hyphen
- refactor(military): make method static
- feat(military): check end for existence
- refactor(military): use it.each for invalid cases
- feat(military): check start for existence
- feat(military): ensure end of range includes colon
- feat(military): ensure start of range includes colon
- test(military): add new valid case
- test(military): compare hours
- feat(military): in same hour, compare minutes
- test(military): add test
- test(military): add test
- refactor(military): use it.each for valid cases
- feat(military): restrict to 24 hours
- feat(military): restrict to 24 hours exclusive
- test(military): add full range
- test(military): add full range plus one minute
- feat(military): allow ranges to wrap around a day
- feat(military): restrict to 60 minutes in an hour
- feat(military): restrict to 60 minutes in an hour for start
- refactor(military): simplify tests
- feat(military): add negative start hour check
- feat(military): add negative end hour check
- feat(military): add negative start minute check
- feat(military): add negative end minute check
- test(military): check bad separator
- feat(military): prevent extra separators
- refactor(military): move logic to private methods
- refactor(military): simplify boolean logic
